### PR TITLE
OE-6186 - Remove BOTH eyes option

### DIFF
--- a/protected/config/core/common.php
+++ b/protected/config/core/common.php
@@ -370,6 +370,7 @@ return array(
         'event_lock_disable' => false,
         'reports' => array(
         ),
+        'opbooking_disable_both_eyes' => true,
         'html_autocomplete' => 'off',
         // html|pdf, pdf requires wkhtmltopdf with patched QT
         'event_print_method' => 'pdf',

--- a/protected/config/core/common.php
+++ b/protected/config/core/common.php
@@ -370,7 +370,7 @@ return array(
         'event_lock_disable' => false,
         'reports' => array(
         ),
-        'opbooking_disable_both_eyes' => true,
+        'opbooking_disable_both_eyes' => false,
         'html_autocomplete' => 'off',
         // html|pdf, pdf requires wkhtmltopdf with patched QT
         'event_print_method' => 'pdf',

--- a/protected/modules/OphTrOperationbooking/views/default/form_Element_OphTrOperationbooking_Operation.php
+++ b/protected/modules/OphTrOperationbooking/views/default/form_Element_OphTrOperationbooking_Operation.php
@@ -17,7 +17,24 @@
  */
  ?>
 <fieldset class="element-fields">
-	<?php echo $form->radioButtons($element, 'eye_id', CHtml::listData(Eye::model()->findAll(array('order' => 'display_order asc')), 'id', 'name'))?>
+	<?php
+	/**
+	 * Check the Subspecialty is 'Cataract', and check opbooking_disable_both_eyes is True.  Used to remove BOTH eyes option for Cataract operations.
+	 */
+	if ($episode = $this->patient->getEpisodeForCurrentSubspecialty()) {
+	}
+	?>
+	<?php
+		if ($episode->getSubspecialtyText() == "Cataract" And Yii::app()->params['opbooking_disable_both_eyes'] == true) {
+			?>
+			<?php echo $form->radioButtons($element, 'eye_id', CHtml::listData(Eye::model()->findAll(array('condition' => 'name != "Both"', 'order' => 'display_order asc')), 'id', 'name'))?>
+	<?php
+		} else {
+	?>
+			<?php echo $form->radioButtons($element, 'eye_id', CHtml::listData(Eye::model()->findAll(array('order' => 'display_order asc')), 'id', 'name'))?>
+	<?php
+	}
+	?>
 	<?php $form->widget('application.widgets.ProcedureSelection', array(
         'element' => $element,
         'durations' => true,


### PR DESCRIPTION
Remove BOTH eyes option for Cataract Operations, and based on flag.

Added opbooking_disable_both_eyes = true to common.php
Added check in form_Element_OphTrOperationbooking_Operation.php that subspecialty is Cataract and that opbooking_disable_both_eyes is true.

So if a Op Booking is being made with a Cataract Subspecialty then the BOTH will not display.  If any other booking is being made then BOTH will be available.

If common.php is altered to make opbooking_disable_both_eyes set to false then BOTH eyes will be an option for all subspecialties Operation Booking.