### PR TITLE
OE-6228 - Issue with Eye assignment changing from Examination to CVI …

### DIFF
--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -1086,7 +1086,6 @@ class Patient extends BaseActiveRecordVersioned
 
         foreach ($this->episodes as $ep) {
             if ($ep->eye_id){
-            //primary disorder for episode
                 if ($ep->disorder_id && (is_null($eye_id) || $ep->eye_id == $eye_id)) {
                     $disorder_ids[] = $ep->disorder_id;
                 }

--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -1085,12 +1085,13 @@ class Patient extends BaseActiveRecordVersioned
         }
 
         foreach ($this->episodes as $ep) {
+            if ($ep->eye_id){
             //primary disorder for episode
-            if ($ep->disorder_id) {
+            if ($ep->disorder_id AND $ep->eye_id == $eye_id) {
                 $disorder_ids[] = $ep->disorder_id;
             }
+            }
         }
-
         return array_unique($disorder_ids);
     }
 

--- a/protected/models/Patient.php
+++ b/protected/models/Patient.php
@@ -1087,9 +1087,9 @@ class Patient extends BaseActiveRecordVersioned
         foreach ($this->episodes as $ep) {
             if ($ep->eye_id){
             //primary disorder for episode
-            if ($ep->disorder_id AND $ep->eye_id == $eye_id) {
-                $disorder_ids[] = $ep->disorder_id;
-            }
+                if ($ep->disorder_id && (is_null($eye_id) || $ep->eye_id == $eye_id)) {
+                    $disorder_ids[] = $ep->disorder_id;
+                }
             }
         }
         return array_unique($disorder_ids);


### PR DESCRIPTION
…creation.

Change to Patient.php to deal with issue where data was being returned without an eye_id and causing issues with the Principal eye diagnosis.

Tested with the following options:
Age-related macular degeneration and Diabetic Retinopathy - swapping from side to side and changing which one was Principal.