### PR TITLE
OE-6246 - eCVI issues.

### DIFF
--- a/protected/modules/OphCoCvi/components/OphCoCvi_Manager.php
+++ b/protected/modules/OphCoCvi/components/OphCoCvi_Manager.php
@@ -765,7 +765,7 @@ class OphCoCvi_Manager extends \CComponent
     {
 
         if (isset($filter['show_issued']) && (bool)$filter['show_issued']) {
-            $criteria->addCondition('t.is_draft = :isdraft', 'OR');
+            $criteria->addCondition('t.is_draft = :isdraft', 'AND');
             $criteria->params[':isdraft'] = false;
         }
         if (!array_key_exists('issue_complete', $filter) || (isset($filter['issue_complete']) && (bool)$filter['issue_complete'])) {


### PR DESCRIPTION
Multiple issues with eCVI.
1. Extra commas on some addresses on printout
2. Consultants pin not treated as a Password
3. Hospital Name not used on Printout by address
4. MISSING
5. Preferred Language override
6. Extra CVI List Filter option
7. UNKNOWN REQUIREMENTS