### PR TITLE
Feature/oe 6316

### DIFF
--- a/protected/migrations/m170119_125608_add_new_preferred_info_fmt.php
+++ b/protected/migrations/m170119_125608_add_new_preferred_info_fmt.php
@@ -1,0 +1,34 @@
+<?php
+
+class m170119_125608_add_new_preferred_info_fmt extends CDbMigration
+{
+	public function up()
+	{
+        $this->insert('ophcocvi_clericinfo_preferred_info_fmt', array(
+            'name' => 'No Preference',
+            'require_email' => '0',
+            'active' => '1',
+            'display_order' => '5',
+            'code' => 'NOPREF',
+            'last_modified_user_id' => '1',
+            'created_user_id' => '1',
+            'deleted' => '0',
+        ));
+	}
+
+	public function down()
+	{
+        $this->delete('ophcocvi_clericinfo_preferred_info_fmt', '`name`="No Preference"');
+	}
+
+	/*
+	// Use safeUp/safeDown to do migration with transaction
+	public function safeUp()
+	{
+	}
+
+	public function safeDown()
+	{
+	}
+	*/
+}

--- a/protected/modules/OphCoCvi/models/Element_OphCoCvi_ConsentSignature.php
+++ b/protected/modules/OphCoCvi/models/Element_OphCoCvi_ConsentSignature.php
@@ -102,7 +102,7 @@ class Element_OphCoCvi_ConsentSignature extends \BaseEventTypeElement
         return array(
             'id' => 'ID',
             'event_id' => 'Event',
-            'is_patient' => 'Is patient',
+            'is_patient' => 'Patient',
             'signature_date' => 'Signature date',
             'representative_name' => 'Representative name',
             'signature_file_id' => 'Signature File',

--- a/protected/modules/OphCoCvi/views/default/form_Element_OphCoCvi_ConsentSignature.php
+++ b/protected/modules/OphCoCvi/views/default/form_Element_OphCoCvi_ConsentSignature.php
@@ -22,10 +22,11 @@
         array('style' => 'width: 110px;')) ?>
     <fieldset id="OEModule_OphCoCvi_models_Element_OphCoCvi_ConsentSignature_is_patient" class="row field-row">
         <div class="large-2 column">
-            <label>Is patient:</label>
+            <label>Patient:</label>
         </div>
         <div class="large-10 column end">
-            <?php echo $form->radioBoolean($element, 'is_patient', array('nowrapper' => true)) ?>
+            <?php echo $form->checkBox($element, 'is_patient', array('nowrapper' => true)) ?>
+            <?php //echo $form->radioBoolean($element, 'is_patient', array('nowrapper' => true)) ?>
         </div>
     </fieldset>
 

--- a/protected/modules/OphCoCvi/views/default/form_Element_OphCoCvi_ConsentSignature.php
+++ b/protected/modules/OphCoCvi/views/default/form_Element_OphCoCvi_ConsentSignature.php
@@ -22,14 +22,20 @@
         array('style' => 'width: 110px;')) ?>
     <fieldset id="OEModule_OphCoCvi_models_Element_OphCoCvi_ConsentSignature_is_patient" class="row field-row">
         <div class="large-2 column">
-            <label>Patient:</label>
+            <label>Signed By:</label>
         </div>
         <div class="large-10 column end">
-            <?php echo $form->checkBox($element, 'is_patient', array('nowrapper' => true)) ?>
-            <?php //echo $form->radioBoolean($element, 'is_patient', array('nowrapper' => true)) ?>
+            <?php echo $form->radioButtons($element, 'is_patient', array(
+                1 => 'Patient',
+                0 => "Patient's Representative",
+            ),
+                $element->is_patient,
+                false, false, false, false,
+                array('nowrapper' => true)
+            ); ?>
+            <?php // echo $form->radioBoolean($element, 'is_patient', array('nowrapper' => true)) ?>
         </div>
     </fieldset>
-
     <?php echo $form->textField($element, 'representative_name', array('hide' => $element->is_patient), null, array('field' => 4)) ?>
 
 </div>

--- a/protected/views/admin/commissioning_body_services.php
+++ b/protected/views/admin/commissioning_body_services.php
@@ -49,7 +49,7 @@ if (!isset($base_data_url)) {
 				<?php
 				$criteria = new CDbCriteria();
 				$criteria->with = array('commissioning_body');
-				$criteria->order = 't.name asc';
+				$criteria->order = 'LOWER(t.name) asc';
 
 				if (isset($commissioning_bt)) {
 					$criteria->addColumnCondition(array('commissioning_body.commissioning_body_type_id' => $commissioning_bt->id));


### PR DESCRIPTION
Multiple changes to eCVI

1. Preferred information format drop-down needs a "No preference" option. When this is selected, all corresponding tick boxes on the form should remain empty.
2. Change the CVI form's "is patient?" label to allow clearer selection of "patient" or "patient's representative".
3. On the Local Authority admin screen, ensure records are sorted alphabetically