### PR TITLE
Fixed Issue 951: Address Type is Not Saved

### DIFF
--- a/protected/models/Address.php
+++ b/protected/models/Address.php
@@ -68,9 +68,9 @@ class Address extends BaseActiveRecordVersioned
             array('postcode', 'length', 'max' => 10),
             array('email', 'length', 'max' => 255),
             array('email','email'),
-            array('country_id, type, date_start, date_end', 'safe'),
+            array('country_id, address_type_id, date_start, date_end', 'safe'),
             array('country_id, contact_id', 'required'),
-            array('id, address1, address2, city, postcode, county, email, country_id, type, date_start, date_end', 'safe', 'on' => 'search'),
+            array('id, address1, address2, city, postcode, county, email, country_id, address_type_id, date_start, date_end', 'safe', 'on' => 'search'),
         );
     }
 


### PR DESCRIPTION
Fixed an issue where the address type could not be changed when editing the address of a Patient/Practice/GP etc.