### PR TITLE
OE-6803 - Clear up confusion between 'Service' and 'Firm' for partial bookings waiting list

### DIFF
--- a/protected/modules/OphTrOperationbooking/controllers/WaitingListController.php
+++ b/protected/modules/OphTrOperationbooking/controllers/WaitingListController.php
@@ -178,14 +178,12 @@ class WaitingListController extends BaseModuleController
     {
         YiiSession::set('waitinglist_searchoptions', 'subspecialty-id', $_POST['subspecialty_id']);
 
-        echo CHtml::tag('option', array('value' => ''), CHtml::encode('All firms'), true);
+        echo CHtml::tag('option', array('value' => ''), CHtml::encode("All ".Yii::app()->params['service_firm_label']."s"), true);
 
-        if (!empty($_POST['subspecialty_id'])) {
-            $firms = $this->getFilteredFirms($_POST['subspecialty_id']);
+        $firms = $this->getFilteredFirms($_POST['subspecialty_id']);
 
-            foreach ($firms as $id => $name) {
-                echo CHtml::tag('option', array('value' => $id), CHtml::encode($name), true);
-            }
+        foreach ($firms as $id => $name) {
+            echo CHtml::tag('option', array('value' => $id), CHtml::encode($name), true);
         }
     }
 
@@ -241,8 +239,11 @@ class WaitingListController extends BaseModuleController
     protected function getFilteredFirms($subspecialtyId)
     {
         $criteria = new CDbCriteria();
-        $criteria->addCondition('subspecialty_id = :subspecialtyId');
-        $criteria->params[':subspecialtyId'] = $subspecialtyId;
+        if($subspecialtyId > 0){
+            $criteria->addCondition('subspecialty_id = :subspecialtyId');
+            $criteria->params[':subspecialtyId'] = $subspecialtyId;
+        }
+        $criteria->addCondition('can_own_an_episode = 1');
         $criteria->order = '`t`.name asc';
 
         return CHtml::listData(Firm::model()

--- a/protected/modules/OphTrOperationbooking/views/waitingList/index.php
+++ b/protected/modules/OphTrOperationbooking/views/waitingList/index.php
@@ -86,8 +86,8 @@
 				<table class="grid">
 					<thead>
 					<tr>
-						<th>Service:</th>
-						<th>Firm:</th>
+						<th>Subspeciality:</th>
+						<th><?php echo ucfirst(Yii::app()->params['service_firm_label']); ?>:</th>
 						<th>Next letter due:</th>
 						<th>Site:</th>
 						<th>Hospital no:</th>
@@ -102,19 +102,20 @@
                                     'type' => 'POST',
                                     'data' => array('subspecialty_id' => 'js:this.value', 'YII_CSRF_TOKEN' => Yii::app()->request->csrfToken),
                                     'url' => Yii::app()->createUrl('/OphTrOperationbooking/waitingList/filterFirms'),
-                                    'success' => "js:function(data) {
-											if ($('#subspecialty-id').val() != '') {
-												$('#firm-id').attr('disabled', false);
-												$('#firm-id').html(data);
-											} else {
-												$('#firm-id').attr('disabled', true);
-												$('#firm-id').html(data);
-											}
-										}",
+                                    'success' => "js:function(data) { $('#firm-id').html(data); }",
                                 )))?>
 						</td>
 						<td>
-							<?php echo CHtml::dropDownList('firm-id', @$_POST['firm-id'], $this->getFilteredFirms(@$_POST['subspecialty-id']), array('empty' => 'All firms', 'disabled' => !@$_POST['firm-id']))?>
+							<?php
+                                $filtered_firms = $this->getFilteredFirms(@$_POST['subspecialty-id']);
+
+                                $selected = (count($filtered_firms) == 1 ? reset(array_keys($filtered_firms)) : @$_POST['firm-id']);
+                                $options = array(
+                                        'disabled' => !@$_POST['firm-id'],
+                                        'empty' => "All ".Yii::app()->params['service_firm_label']."s"
+                                    );
+
+                                echo CHtml::dropDownList('firm-id', $selected , $filtered_firms, $options) ?>
 						</td>
 						<td>
 							<?php echo CHtml::dropDownList('status', @$_POST['status'], Element_OphTrOperationbooking_Operation::getLetterOptions())?>


### PR DESCRIPTION
    Renamed 'Service' dropdown to "Subspecialty"
    Renamed 'Firm' dropdown to service_firm_label param
    Renamed 'All firms' entry to use service_firm_label param
    The 'Firm' list no longer show firms where !firm.can_own_an_episode
    When only 1 option exists, it is now selected by default
    When 'All subspecialties' is selected in the 'Subspecialty' dropdown, the firms dropdown llists ALL firms where firm.can_own_an_episode = 1