### PR TITLE
Fix #1053

### DIFF
--- a/protected/models/Drug.php
+++ b/protected/models/Drug.php
@@ -72,7 +72,7 @@ class Drug extends BaseActiveRecordVersioned
             array('name, tallman', 'required'),
             array('name', 'unsafe', 'on' => 'update'),
             array('tallman, dose_unit, default_dose, type_id, form_id, default_duration_id, default_frequency_id, '
-                .'default_route_id, preservative_free, active, allergies, aliases, national_code, tags', 'safe'),
+                .'default_route_id, active, allergies, aliases, national_code, tags', 'safe'),
         );
     }
 

--- a/protected/modules/OphDrPrescription/models/OphDrPrescription_ReportPrescribedDrugs.php
+++ b/protected/modules/OphDrPrescription/models/OphDrPrescription_ReportPrescribedDrugs.php
@@ -84,13 +84,14 @@ class OphDrPrescription_ReportPrescribedDrugs extends BaseReport
 
     public function toCSV()
     {
-        $output = "Patient's no,  Patient's Surname, Patient's First name,  Patient's DOB, Patient's Post code, Date of Prescription, Drug name, Prescribed Clinician's name, Prescribed Clinician's Job-role, Prescription event date\n";
+        $output = "Patient's no,  Patient's Surname, Patient's First name,  Patient's DOB, Patient's Post code, Date of Prescription, Drug name, Prescribed Clinician's name, Prescribed Clinician's Job-role, Prescription event date, Preservative Free\n";
         foreach ($this->items as $item) {
             $drug = new Drug();
             $drug->attributes = $item;
             $output .= $item['hos_num'].', '.$item['last_name'].', '.$item['first_name'].', '.($item['dob'] ? date('j M Y', strtotime($item['dob'])) : 'Unknown').', '.$item['postcode'].', ';
             $output .= (date('j M Y', strtotime($item['created_date'])).' '.(substr($item['created_date'], 11, 5))).', '.$drug->tallmanLabel.', ';
-            $output .= $item['user_first_name'].' '.$item['user_last_name'].', '.$item['role'].', '.(date('j M Y', strtotime($item['event_date'])).' '.(substr($item['event_date'], 11, 5)));
+            $output .= $item['user_first_name'].' '.$item['user_last_name'].', '.$item['role'].', '.(date('j M Y', strtotime($item['event_date'])).' '.(substr($item['event_date'], 11, 5))) . ', ';
+            $output .= $item['preservative_free'] ? 'Yes' : 'No';
             $output .= "\n";
         }
 

--- a/protected/modules/OphDrPrescription/views/report/_prescribeddrugs.php
+++ b/protected/modules/OphDrPrescription/views/report/_prescribeddrugs.php
@@ -29,6 +29,7 @@
             <th>Prescribed Clinician’s name</th>
             <th>Prescribed Clinician’s Job-role</th>
             <th>Prescription event date</th>
+            <th>Preservative Free</th>
         </tr>
     </thead>
     <tbody>
@@ -53,6 +54,7 @@
                     <td><?php echo $drug['user_first_name'].' '.$drug['user_last_name']; ?></td>
                     <td><?php echo $drug['role']; ?></td>
                     <td><?php echo date('j M Y', strtotime($drug['event_date']))?> <?php echo substr($drug['event_date'], 11, 5)?></td>
+                    <td><?php echo $drug['preservative_free'] ? 'Yes' : 'No'; ?></td>
                 </tr>
             <?php endforeach; ?>
         <?php endif; ?>

--- a/protected/modules/OphDrPrescription/views/report/prescribedDrugs.php
+++ b/protected/modules/OphDrPrescription/views/report/prescribedDrugs.php
@@ -190,6 +190,6 @@
 
    
 
-    <div class="reportSummary report curvybox white blueborder" style="display: none;">
+    <div class="reportSummary report curvybox white blueborder" style="display: none; overflow: auto">
     </div>
 </div>


### PR DESCRIPTION
Fix #1053: Remove the defunct "preservative_free" field from the Drug model that causes the prescribed drugs report to crash, and add the field that replaced it to the report (which is queried, but not displayed)